### PR TITLE
feat: build & lint for pushes to main & PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,10 @@
-name: Publish to PyPI
+name: Build, Lint, and Publish
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:
@@ -15,39 +19,61 @@ on:
           - pypi
 
 jobs:
-  publish:
+  build-and-lint:
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'release' && 'pypi' || github.event.inputs.environment }}
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.13'
-    
+
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:
         version: "latest"
         enable-cache: true
-    
+
     - name: Install dependencies
       run: uv sync --dev
-    
+
     - name: Run lints
       run: uv run python scripts/lint.py
-    
+
     - name: Build package
       run: uv build
-    
+
+  publish:
+    needs: build-and-lint
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'release' && 'pypi' || github.event.inputs.environment }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        version: "latest"
+        enable-cache: true
+
+    - name: Build package
+      run: uv build
+
     - name: Publish to TestPyPI
       if: github.event.inputs.environment == 'testpypi' || github.event_name == 'workflow_dispatch'
       env:
         UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
       run: uv publish --publish-url https://test.pypi.org/legacy/
-    
+
     - name: Publish to PyPI
       if: github.event_name == 'release' || github.event.inputs.environment == 'pypi'
       env:


### PR DESCRIPTION
- Add push (main) and pull_request triggers
- Split into build-and-lint and publish jobs
- build-and-lint runs on all events (push, PR, release, workflow_dispatch)
- publish job only runs on release and workflow_dispatch events
- publish job depends on build-and-lint passing